### PR TITLE
Doc update & Clearer log for angular error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# Sentry.io for nativescript
+# Sentry.io for NativeScript
+
+[![npm](https://img.shields.io/npm/v/nativescript-sentry.svg)](https://www.npmjs.com/package/nativescript-sentry)
+[![npm](https://img.shields.io/npm/dt/nativescript-sentry.svg?label=npm%20downloads)](https://www.npmjs.com/package/nativescript-sentry)
 
 This plugin uses sentry-android and sentry-cocoa to catch native errors/stack traces and send them to a sentry server.
 
 **NOTE:** If you have a **native exeption** and the app exits the plugin will save the log and send it in the **next app startup**, this is how the native plugins are implemented and it is expected behavior
 
-## Installation
+# Installation
 
 ```javascript
 tns plugin add nativescript-sentry
 ```
 
-## Usage
+# Config
 
 ### Without Angular
 
@@ -35,15 +38,9 @@ NgModule({
 
 **Note:** this plugin adds a custom ErrorHandler to your angular app
 
-## API
+# API
 
-### Init Sentry
-
-```typescript
-Sentry.init(dsn: string);
-```
-
-### Capture Exception
+#### Capture Exception
 
 ```typescript
 Sentry.captureException(exeption: Error, options?: ExceptionOptions);
@@ -59,47 +56,101 @@ try {
 }
 ```
 
-### Capture Message
+#### Capture Message
 
 ```typescript
 Sentry.captureMessage(message: string, options?: MessageOptions)
 ```
 
-### Capture BreadCrumb
+#### Capture BreadCrumb
 
 ```typescript
 Sentry.captureBreadcrumb(breadcrumb: BreadCrumb)
 ```
 
-### Set Context user
+#### Set Context user
 
 ```typescript
 Sentry.setContextUser(user: SentryUser)
 ```
 
-### Context Tags
+#### Context Tags
 
 ```typescript
 Sentry.setContextTags(tags: object)
 ```
 
-### Context Extra
+#### Context Extra
 
 ```typescript
 Sentry.setContextExtra(extra: object)
 ```
 
-### Clear context
+#### Clear context
 
 ```typescript
 Sentry.clearContext();
+```
+
+## Enums
+
+```typescript
+export enum Level {
+  Fatal = 'fatal',
+  Error = 'error',
+  Warning = 'warning',
+  Info = 'info',
+  Debug = 'debug'
+}
+```
+
+## Interfaces
+
+```typescript
+export interface SentryUser {
+  id: string;
+  email?: string;
+  username?: string;
+}
+
+export interface BreadCrumb {
+  message: string;
+  category: string;
+  level: Level;
+}
+
+export interface MessageOptions {
+  level?: Level;
+
+  /**
+   * Object of additional Key/value pairs which generate breakdowns charts and search filters.
+   */
+  tags?: object;
+
+  /**
+   * Object of unstructured data which is stored with events.
+   */
+  extra?: object;
+}
+
+export interface ExceptionOptions {
+  /**
+   * Object of additional Key/value pairs which generate breakdowns charts and search filters in Sentry.
+   */
+  tags?: object;
+
+  /**
+   * Object of unstructured data which is stored with events.
+   */
+  extra?: object;
+}
 ```
 
 ### Next features:
 
 - callback for events
 
-### Changelog:
+## Changelog:
 
 **28/11/2018 - (1.6.1):**
 

--- a/src/angular/error.handler.ts
+++ b/src/angular/error.handler.ts
@@ -17,7 +17,7 @@ export class SentryErrorHandler extends ErrorHandler {
     try {
       Sentry.captureException(err, null);
     } catch (e) {
-      console.log('[Sentry - SentryErrorHandler]', e);
+      console.log('[NativeScript-Sentry - SentryErrorHandler]', e);
     }
     throw err;
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -94,4 +94,11 @@ export interface ExceptionOptions {
    * Object of unstructured data which is stored with events.
    */
   extra?: object;
+
+  /**
+   * ** iOS Only **
+   * A boolean value that when true the provided Error instance will be sent to Sentry as a stringified JSON object.
+   * This will allow Sentry to have the `Error.message, Error.name, and Error.stacktrace` included.
+   */
+  useJsonError?: boolean;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -94,11 +94,4 @@ export interface ExceptionOptions {
    * Object of unstructured data which is stored with events.
    */
   extra?: object;
-
-  /**
-   * ** iOS Only **
-   * A boolean value that when true the provided Error instance will be sent to Sentry as a stringified JSON object.
-   * This will allow Sentry to have the `Error.message, Error.name, and Error.stacktrace` included.
-   */
-  useJsonError?: boolean;
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-sentry",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Sentry.io NativeScript plugin.",
   "main": "sentry",
   "typings": "index.d.ts",

--- a/src/sentry.android.ts
+++ b/src/sentry.android.ts
@@ -41,7 +41,12 @@ export class Sentry {
       this.setContextTags(options.tags);
     }
 
-    const ex = new java.lang.Throwable(exception.stack);
+    const cause = new java.lang.Throwable(exception.stack);
+
+    // creating a new Exception to send to Sentry which will include the
+    // JS Error stacktrace as the "cause" and the JS Error message as the Throwable "message"
+    // https://developer.android.com/reference/java/lang/Exception.html#Exception(java.lang.String,%20java.lang.Throwable)
+    const ex = new java.lang.Exception(exception.message, cause);
     io.sentry.Sentry.getStoredClient().sendException(ex);
   }
 

--- a/src/sentry.ios.ts
+++ b/src/sentry.ios.ts
@@ -30,17 +30,13 @@ export class Sentry {
 
   public static captureException(exception: Error, options?: ExceptionOptions) {
     const event = SentryEvent.alloc().initWithLevel(SentrySeverity.kSentrySeverityError);
-    event.message = exception.stack ? exception.stack : exception.message;
 
-    // if the user wants to use JSON error, set the event.message
-    if (options && options.useJsonError === true) {
-      // event.message = JSON.stringify(exception);
-      event.message = JSON.stringify({
-        message: exception.message,
-        stacktrace: exception.stack,
-        name: exception.name
-      });
-    }
+    // create a string of the entire Error for sentry to display as much info as possible
+    event.message = JSON.stringify({
+      message: exception.message,
+      stacktrace: exception.stack,
+      name: exception.name
+    });
 
     if (options && options.extra) {
       event.tags = NSDictionary.dictionaryWithDictionary(options.extra as NSDictionary<string, string>);

--- a/src/sentry.ios.ts
+++ b/src/sentry.ios.ts
@@ -32,6 +32,16 @@ export class Sentry {
     const event = SentryEvent.alloc().initWithLevel(SentrySeverity.kSentrySeverityError);
     event.message = exception.stack ? exception.stack : exception.message;
 
+    // if the user wants to use JSON error, set the event.message
+    if (options && options.useJsonError === true) {
+      // event.message = JSON.stringify(exception);
+      event.message = JSON.stringify({
+        message: exception.message,
+        stacktrace: exception.stack,
+        name: exception.name
+      });
+    }
+
     if (options && options.extra) {
       event.tags = NSDictionary.dictionaryWithDictionary(options.extra as NSDictionary<string, string>);
     }


### PR DESCRIPTION
- Add `nativescript` to the console.log for angular error handler
- Add enums/interfaces to the README for easier/quicker understanding of the types being used in the API on the README.