### PR TITLE
Prevent throw when js exceptions should be discarded

### DIFF
--- a/demo-ng/src/package.json
+++ b/demo-ng/src/package.json
@@ -2,5 +2,6 @@
     "main": "main.js",
     "android": {
         "v8Flags": "--expose_gc"
-    }
+    },
+    "discardUncaughtJsExceptions": true,
 }


### PR DESCRIPTION
Hi,

I just noticed when upgrading the app that the `ErrorHandler` in the plugin was throwing every catched JS exception, which cause the app to crash. 
Unless all codebase is wrapped in a `try/catch`, it's impossible for an application to deal with any error scenario.

Those exceptions should not be thrown out when `discardUncaughtJsExceptions` is set to true. The exception is already catched and sent to Sentry.

What do you think?