### PR TITLE
Add support for using a factory to supply the dsn

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,52 @@ Sentry.init(dsn);
 
 ### With Angular
 
+Add the dsn directly:
 ```typescript
 import { SentryModule } from 'nativescript-sentry/angular';
 
 NgModule({
   ...
   imports: [
-       SentryModule.forRoot({dsn: 'https://<key>:<secret>@host/<project>'})
+    SentryModule.forRoot({
+      config: {
+        dsn: 'https://<key>:<secret>@host/<project>'
+      }
+    })
   ],
 
 ```
+
+Or use a provider:
+```typescript
+import { SentryModule, SentryService } from 'nativescript-sentry/angular';
+import { EnvironmentService } from './app/environment.service';
+
+...
+
+export function sentryServiceOptionsFactory(environmentService) {
+  return {
+    dsn: environmentService.getSentryDsn()
+  };
+}
+
+...
+
+NgModule({
+  ...
+  imports: [
+    SentryModule.forRoot({
+      sentryServiceProvider: {
+        provide: SentryService,
+        useFactory: sentryServiceOptionsFactory,
+        deps: [EnvironmentService]
+      }
+    })
+  ],
+  providers: [EnvironmentService]
+
+```
+**Note**: If a `sentryServiceProvider` is defined the `config` property will be ignored.
 
 **Note:** this plugin adds a custom ErrorHandler to your angular app
 

--- a/src/angular/app.module.d.ts
+++ b/src/angular/app.module.d.ts
@@ -1,7 +1,10 @@
-import { InjectionToken, ModuleWithProviders } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, Provider } from '@angular/core';
 import { SentryErrorHandler } from './error.handler';
 export interface SentryConfig {
-  dsn: string;
+  sentryServiceProvider?: Provider;
+  config?: {
+    dsn: string;
+  };
 }
 export declare const SentryService: InjectionToken<SentryConfig>;
 export declare class SentryModule {

--- a/src/angular/app.module.ts
+++ b/src/angular/app.module.ts
@@ -1,19 +1,22 @@
-import { ErrorHandler, InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
+import { ErrorHandler, InjectionToken, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { SentryErrorHandler } from './error.handler';
 
 export interface SentryConfig {
-  dsn: string;
+  sentryServiceProvider?: Provider;
+  config?: {
+    dsn: string;
+  };
 }
 
 export const SentryService = new InjectionToken<SentryConfig>('SentryConfig');
 
 @NgModule()
 export class SentryModule {
-  static forRoot(config: SentryConfig): ModuleWithProviders {
+  static forRoot(options: SentryConfig): ModuleWithProviders {
     return {
       ngModule: SentryModule,
       providers: [
-        { provide: SentryService, useValue: config },
+        options.sentryServiceProvider || { provide: SentryService, useValue: options.config },
         {
           provide: ErrorHandler,
           useFactory: provideSentryServiceOptions,


### PR DESCRIPTION
Hey,

I made some small changes that will allow us to use a factory for supplying the dsn when we use the plugin in combination with Angular. This should resolve #8 

