### PR TITLE
tells reader where dsn can be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ tns plugin add nativescript-sentry
 
 # Config
 
+Your project's dsn url can be found in the DSN field on the keys page of the sentry dashboard here:
+```
+https://sentry.io/settings/<organization-slug>/projects/<project-name>/keys/
+```
+
 ### Without Angular
 
 ```typescript


### PR DESCRIPTION
this tripped me up a bit- the sentry dashboard looks pretty cool, but it can be kind of overwhelming to a newcomer and hard to track down exactly where the dsn is located (and people can potentially go down rabbit hole(s) of trying to use the wrong thing from other pages like I did).

This PR calls out that you can go straight to the "keys" page in the sentry dashboard and find it there (though we can't necessarily link right to it since it's based on the user's org and project names).